### PR TITLE
[vf-CI.yml GH Action] add ttfa install step

### DIFF
--- a/.github/workflows/vf-CI.yml
+++ b/.github/workflows/vf-CI.yml
@@ -27,6 +27,8 @@ jobs:
         with:
           update-wheel: "true"
           update-setuptools: "true"
+      - name: Install ttfautohint (Ubuntu package manager)
+        run: sudo apt-get install ttfautohint
       - name: Build fonts
         run: cd sources && ./build.sh && cd ..
       - name: Font Bakery CI tests


### PR DESCRIPTION
Adds ttfautohint installation to GH Action configuration to address missing ttfautohint at fontmake `-a` flag autohint step of the build process.